### PR TITLE
docs: fix typos

### DIFF
--- a/cli_support/license_tools.py
+++ b/cli_support/license_tools.py
@@ -56,7 +56,7 @@ class LicenseTools:
         be ready to be shipped to customers.
         Please note that this is a very simplified approach."""
         licenseUpper = spdx_identifier.upper()
-        if "GPL" in licenseUpper:  # incudes LGPL
+        if "GPL" in licenseUpper:  # includes LGPL
             return True
         if "CDDL" in licenseUpper:
             return True

--- a/show_licenses.py
+++ b/show_licenses.py
@@ -66,7 +66,7 @@ class ShowLicenses():
         except OSError as ex:
             print(Fore.LIGHTRED_EX)
             print("    Error reading CLI file: " + cli_filename)
-            print("    Error '{0}' occured. Arguments {1}.".format(ex.errno, ex.args))
+            print("    Error '{0}' occurred. Arguments {1}.".format(ex.errno, ex.args))
             print(Fore.RESET)
             return
 


### PR DESCRIPTION
Found via `codespell -H`